### PR TITLE
Add mnist training script & model trained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # Etc
 .DS_Store
+data

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ env:
 	conda create -n $(BASENAME)  python=$(PYTHON)
 
 setup:
-	conda install --file requirements.txt -c conda-forge
+	conda install --file requirements.txt -c conda-forge -c pytorch
 	pre-commit install
 
 format:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Training Conv Net with MNIST
+
+1. Go to `src/ml`
+2. Run `python train.py`
+
 ## File Structure
 ```bash
 .

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ MNIST inference server w/ FastAPI
 1. Go to `src/ml`
 2. Run `python train.py`
 
+## References
+- https://github.com/pytorch/examples/blob/master/mnist/main.py
+
 
 ## File Structure
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,7 @@ pytest-pylint   == 0.18.0
 pytest-flake8   == 1.0.7
 pytest-mypy     == 0.8.0
 pytest-cov      == 3.0.0        # coverage reports
+
+# ml
+pytorch         == 1.10.2
+torchvision     == 0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ pytest-cov      == 3.0.0        # coverage reports
 # ml
 pytorch         == 1.10.2
 torchvision     == 0.9.1
+
+# utils
+tqdm            == 4.62.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ profile = black
 
 [flake8]
 max-line-length = 88
-extend-ignore = E203
+extend-ignore = E203, ANN101, SC100
 spellcheck-targets=comments
 
 [pylint]
@@ -19,6 +19,11 @@ disable =
     C0326,  # bad-whitespace
     C0411,  # wrong-import-order
 
+[pylint.typecheck]
+# List of members which are set dynamically and missed by Pylint inference
+# system, and so shouldn't trigger E1101 when accessed.
+generated-members=numpy.*, torch.*
+
 [mypy]
 ignore_missing_imports = True
 
@@ -26,7 +31,7 @@ ignore_missing_imports = True
 filterwarnings = ignore::DeprecationWarning
 
 [coverage:run]
-# omit = file-path-to-omit
+omit = src/ml/*.py
 branch = true
 parallel = true
 

--- a/src/ml/README.md
+++ b/src/ml/README.md
@@ -1,0 +1,22 @@
+## How to train
+
+It saves the model with the best accuracy from training.
+
+```bash
+$ python train.py --help
+usage: train.py [-h] [--batch-size N] [--test-batch-size N] [--epochs N] [--lr LR] [--gamma M] [--no-cuda] [--seed S] [--log-interval N] [--save-model]
+
+PyTorch MNIST Example
+
+optional arguments:
+  -h, --help           show this help message and exit
+  --batch-size N       input batch size for training (default: 64)
+  --test-batch-size N  input batch size for testing (default: 1000)
+  --epochs N           number of epochs to train (default: 14)
+  --lr LR              learning rate (default: 1.0)
+  --gamma M            Learning rate step gamma (default: 0.7)
+  --no-cuda            disables CUDA training
+  --seed S             random seed (default: 1)
+  --log-interval N     how many batches to wait before logging training status
+  --save-model         For Saving the current Model
+```

--- a/src/ml/model.py
+++ b/src/ml/model.py
@@ -1,0 +1,35 @@
+"""A simple image classification model for MNIST.
+
+- Author: Jinwoo Park
+- Email: www.jwpark.co.kr@gmail.com
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+class ConvNet(nn.Module):
+    """A simple image classification model for MNIST."""
+
+    def __init__(self) -> None:
+        """Initialize."""
+        super().__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, inp: torch.Tensor) -> torch.Tensor:
+        """Forward."""
+        feat1 = F.relu(self.conv1(inp))
+        feat2 = F.relu(self.conv2(feat1))
+        cnn_feat = self.dropout1(F.max_pool2d(feat2, 2))
+        cnn_feat = torch.flatten(cnn_feat, 1)
+
+        fc_feat = self.dropout2(F.relu(self.fc1(cnn_feat)))
+        logits = self.fc2(fc_feat)
+        output = F.log_softmax(logits, dim=1)
+        return output

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -19,6 +19,7 @@ from torch import optim
 from torch.optim.lr_scheduler import StepLR
 from torch.utils.data.dataloader import DataLoader
 from torchvision import datasets, transforms
+from tqdm import tqdm
 
 logging.config.fileConfig("../../logging.conf")
 logger = logging.getLogger()
@@ -117,7 +118,8 @@ def train(
 ) -> None:
     """Train the model in a single epoch."""
     model.train()
-    for batch_idx, (data, target) in enumerate(train_loader):
+    epoch = params["epoch"]
+    for data, target in tqdm(train_loader, desc=f"Train Epoch {epoch}"):
         data, target = data.to(device), target.to(device)
 
         # update
@@ -126,19 +128,6 @@ def train(
         loss = F.nll_loss(output, target)
         loss.backward()
         optimizer.step()
-
-        # skip logging
-        if batch_idx % params["log_interval"] != 0:
-            continue
-
-        logger.info(
-            "Train Epoch: %d\t[%5d/%d (%.2f%%)]\tLoss: %.4f",
-            params["epoch"],
-            batch_idx * len(data),
-            len(train_loader.dataset),
-            100 * batch_idx * len(data) / len(train_loader.dataset),
-            loss.item(),
-        )
 
 
 def test(
@@ -149,7 +138,7 @@ def test(
     test_loss = 0.0
     correct = 0
     with torch.no_grad():
-        for data, target in test_loader:
+        for data, target in tqdm(test_loader, desc="Evaluation"):
             data, target = data.to(device), target.to(device)
 
             # sum up batch loss
@@ -164,7 +153,7 @@ def test(
     test_acc = 100.0 * correct / len(test_loader.dataset)
 
     logger.info(
-        "\nTest set: Average loss: %.4f, Accuracy: %d/%d %.2f%%\n",
+        "Test set: Average loss: %.4f\tAccuracy: %d/%d (%.2f%%)",
         test_loss,
         correct,
         len(test_loader.dataset),

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -1,0 +1,215 @@
+"""Train a simple conv net for MNIST dataset.
+
+This script is a little modified from:
+    https://github.com/pytorch/examples/blob/master/mnist/main.py
+
+- Author: Jinwoo Park
+- Email: www.jwpark.co.kr@gmail.com
+"""
+
+import argparse
+import logging
+import logging.config
+from typing import Any, Dict, Tuple
+
+import torch
+import torch.nn.functional as F
+from model import ConvNet
+from torch import optim
+from torch.optim.lr_scheduler import StepLR
+from torch.utils.data.dataloader import DataLoader
+from torchvision import datasets, transforms
+
+logging.config.fileConfig("../../logging.conf")
+logger = logging.getLogger()
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse training settings."""
+    parser = argparse.ArgumentParser(description="PyTorch MNIST Example")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        metavar="N",
+        help="input batch size for training (default: 64)",
+    )
+    parser.add_argument(
+        "--test-batch-size",
+        type=int,
+        default=1000,
+        metavar="N",
+        help="input batch size for testing (default: 1000)",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=10,
+        metavar="N",
+        help="number of epochs to train (default: 14)",
+    )
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=1.0,
+        metavar="LR",
+        help="learning rate (default: 1.0)",
+    )
+    parser.add_argument(
+        "--gamma",
+        type=float,
+        default=0.7,
+        metavar="M",
+        help="Learning rate step gamma (default: 0.7)",
+    )
+    parser.add_argument(
+        "--no-cuda", action="store_true", default=False, help="disables CUDA training"
+    )
+    parser.add_argument(
+        "--seed", type=int, default=1, metavar="S", help="random seed (default: 1)"
+    )
+    parser.add_argument(
+        "--log-interval",
+        type=int,
+        default=10,
+        metavar="N",
+        help="how many batches to wait before logging training status",
+    )
+    parser.add_argument(
+        "--save-model",
+        action="store_true",
+        default=False,
+        help="For Saving the current Model",
+    )
+    args = parser.parse_args()
+    return args
+
+
+def get_dataloaders(
+    batch_size: int, test_batch_size: int, use_cuda: bool
+) -> Tuple[DataLoader, DataLoader]:
+    """Get dataloaders for training and test."""
+    # set kwargs for training and test
+    cuda_kwargs = {"num_workers": 1, "pin_memory": True, "shuffle": True}
+    train_kwargs: Dict[str, Any] = {"batch_size": batch_size}
+    test_kwargs: Dict[str, Any] = {"batch_size": test_batch_size}
+    train_kwargs.update(cuda_kwargs if use_cuda else {})
+    test_kwargs.update(cuda_kwargs if use_cuda else {})
+
+    # set dataset loaders
+    transform_seq = [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+    transform = transforms.Compose(transform_seq)
+    data_path = "../../data"
+    dataset1 = datasets.MNIST(data_path, train=True, download=True, transform=transform)
+    dataset2 = datasets.MNIST(data_path, train=False, transform=transform)
+    train_loader = DataLoader(dataset1, **train_kwargs)
+    test_loader = DataLoader(dataset2, **test_kwargs)
+
+    return train_loader, test_loader
+
+
+def train(
+    model: torch.nn.Module,
+    train_loader: DataLoader,
+    optimizer: optim.Optimizer,
+    params: Dict[str, int],
+    device: torch.device,
+) -> None:
+    """Train the model in a single epoch."""
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        data, target = data.to(device), target.to(device)
+
+        # update
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+
+        # skip logging
+        if batch_idx % params["log_interval"] != 0:
+            continue
+
+        logger.info(
+            "Train Epoch: %d\t[%5d/%d (%.2f%%)]\tLoss: %.4f",
+            params["epoch"],
+            batch_idx * len(data),
+            len(train_loader.dataset),
+            100 * batch_idx * len(data) / len(train_loader.dataset),
+            loss.item(),
+        )
+
+
+def test(
+    model: torch.nn.Module, test_loader: DataLoader, device: torch.device
+) -> float:
+    """Get the test accuracy."""
+    model.eval()
+    test_loss = 0.0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            data, target = data.to(device), target.to(device)
+
+            # sum up batch loss
+            output = model(data)
+            test_loss += F.nll_loss(output, target, reduction="sum").item()
+
+            # get the index of the max log-probability
+            pred = output.argmax(dim=1, keepdim=True)
+            correct += pred.eq(target.view_as(pred)).sum().item()
+
+    test_loss /= len(test_loader.dataset)
+    test_acc = 100.0 * correct / len(test_loader.dataset)
+
+    logger.info(
+        "\nTest set: Average loss: %.4f, Accuracy: %d/%d %.2f%%\n",
+        test_loss,
+        correct,
+        len(test_loader.dataset),
+        test_acc,
+    )
+
+    return test_acc
+
+
+def main() -> None:
+    """Get the conv model with the best acc."""
+    args = parse_args()
+
+    torch.manual_seed(args.seed)
+    use_cuda = not args.no_cuda and torch.cuda.is_available()
+    device = torch.device("cuda" if use_cuda else "cpu")
+
+    train_loader, test_loader = get_dataloaders(
+        batch_size=args.batch_size,
+        test_batch_size=args.test_batch_size,
+        use_cuda=use_cuda,
+    )
+
+    model = ConvNet().to(device)
+    optimizer = optim.Adadelta(model.parameters(), lr=args.lr)
+
+    best_acc = 0.0
+    scheduler = StepLR(optimizer, step_size=1, gamma=args.gamma)
+    for epoch in range(1, args.epochs + 1):
+        train(
+            model=model,
+            train_loader=train_loader,
+            optimizer=optimizer,
+            params={"epoch": epoch, "log_interval": args.log_interval},
+            device=device,
+        )
+        test_acc = test(model, test_loader, device)
+        scheduler.step()
+
+        if args.save_model and test_acc > best_acc:
+            best_acc = test_acc
+            model_scripted = torch.jit.script(model)
+            model_scripted.save("../../mnist_cnn.pt")
+            logger.info("The best model saved")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ml/train.py
+++ b/src/ml/train.py
@@ -79,7 +79,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--save-model",
         action="store_true",
-        default=False,
+        default=True,
         help="For Saving the current Model",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Usage
```bash
$ python train.py --help
usage: train.py [-h] [--batch-size N] [--test-batch-size N] [--epochs N] [--lr LR] [--gamma M] [--no-cuda] [--seed S] [--log-interval N] [--save-model]

PyTorch MNIST Example

optional arguments:
  -h, --help           show this help message and exit
  --batch-size N       input batch size for training (default: 64)
  --test-batch-size N  input batch size for testing (default: 1000)
  --epochs N           number of epochs to train (default: 14)
  --lr LR              learning rate (default: 1.0)
  --gamma M            Learning rate step gamma (default: 0.7)
  --no-cuda            disables CUDA training
  --seed S             random seed (default: 1)
  --log-interval N     how many batches to wait before logging training status
  --save-model         For Saving the current Model
```

The saved model can be used by:
```python
model = torch.jit.load('model_scripted.pt')
model.eval()
```